### PR TITLE
주식 목록 현재가격 기능 보완 - 발행 잔량 조건

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/src/com/school/stockGame/servlet/StockListUI.java
+++ b/src/com/school/stockGame/servlet/StockListUI.java
@@ -40,10 +40,37 @@ public class StockListUI implements Action {
         	int stockNo = stockNameList.get(i).getStockNo();
             String stockName = stockNameList.get(i).getName();
 
-            int currentPrice = dao_detail.getStockPrice(stockNo);
+            // 발행 잔량이 1개 이상일 경우엔, 현재가격은 발행 가격으로 표시한다.
+            // 발행 잔량이 0개일 때부터 학생들이 거래가 이루어지기 때문에, 최신 거래 가격이 현재가격으로 이뤄진다.
+            
+            // 주식 발행 정보 가져오기
+            Map<String, Object> pubInfo = dao_detail.getStockPubInfo(stockNo);
+
+            int pubAmount = 0;
+            int pubPrice = 0;
+
+            // 발행 잔량과 가격이 null이 아닐 때
+            if (pubInfo.get("pubAmount") != null) {
+                pubAmount = ((Number) pubInfo.get("pubAmount")).intValue();
+            }
+
+            if (pubInfo.get("pubPrice") != null) {
+                pubPrice = ((Number) pubInfo.get("pubPrice")).intValue();
+            }
+
+            int currentPrice = 0;
+
+            // 발행잔량이 1이상일 때. 현재가격을 발행 가격으로 표시해주는 조건 넣어줌.
+            if (pubAmount > 0) {
+                currentPrice = pubPrice;
+            } else {
+                currentPrice = dao_detail.getStockPrice(stockNo);
+            }
+
             int prevPrice = dao_detail.getPervPrice(stockNo);
             int priceChange = dao_detail.getStockPriceChange(stockNo);
             int changeRate = dao_detail.getChangeRate(stockNo);
+            
 
             Map<String, Object> stock = new HashMap<String, Object>();
             

--- a/src/com/school/stockGame/servlet/StockListUI.java
+++ b/src/com/school/stockGame/servlet/StockListUI.java
@@ -15,65 +15,72 @@ import com.school.stockGame.dao.StockListDAO;
 import com.school.stockGame.vo.StockVO;
 
 public class StockListUI implements Action {
+	// 주식 목록 첫 화면용
 
-	@Override
-	public String execute(HttpServletRequest request) throws ServletException, IOException {
-		StockListDAO dao_list = new StockListDAO();
-		StockDetailDAO dao_detail = new StockDetailDAO();
-		HttpSession session = request.getSession();
-		
-		String studentId = (String) session.getAttribute("studentId");
+    @Override
+    public String execute(HttpServletRequest request) throws ServletException, IOException {
+
+        StockListDAO dao_list = new StockListDAO();
+        StockDetailDAO dao_detail = new StockDetailDAO();
+        HttpSession session = request.getSession();
+
+        String studentId = (String) session.getAttribute("studentId");
 
         if (studentId == null) {
             studentId = "abc";
         }
-        
+
         // 1. 주식명 목록조회
         List<StockVO> stockNameList = dao_list.getStockNameList();
+
         // 2. JSP에 넘길 주식 목록 데이터 생성
         List<Map<String, Object>> stockList = new ArrayList<Map<String, Object>>();
 
         for (int i = 0; i < stockNameList.size(); i++) {
 
-            //int stockNo = i + 1;
-            
-        	int stockNo = stockNameList.get(i).getStockNo();
+            int stockNo = stockNameList.get(i).getStockNo();
             String stockName = stockNameList.get(i).getName();
 
-            // 발행 잔량이 1개 이상일 경우엔, 현재가격은 발행 가격으로 표시한다.
-            // 발행 잔량이 0개일 때부터 학생들이 거래가 이루어지기 때문에, 최신 거래 가격이 현재가격으로 이뤄진다.
-            
             // 주식 발행 정보 가져오기
             Map<String, Object> pubInfo = dao_detail.getStockPubInfo(stockNo);
 
             int pubAmount = 0;
             int pubPrice = 0;
 
-            // 발행 잔량과 가격이 null이 아닐 때
-            if (pubInfo.get("pubAmount") != null) {
-                pubAmount = ((Number) pubInfo.get("pubAmount")).intValue();
-            }
+            if (pubInfo != null && !pubInfo.isEmpty()) {
 
-            if (pubInfo.get("pubPrice") != null) {
-                pubPrice = ((Number) pubInfo.get("pubPrice")).intValue();
+                if (pubInfo.get("pubAmount") != null) {
+                    pubAmount = ((Number) pubInfo.get("pubAmount")).intValue();
+                }
+
+                if (pubInfo.get("pubPrice") != null) {
+                    pubPrice = ((Number) pubInfo.get("pubPrice")).intValue();
+                }
             }
 
             int currentPrice = 0;
 
-            // 발행잔량이 1이상일 때. 현재가격을 발행 가격으로 표시해주는 조건 넣어줌.
+            // 발행잔량이 1개 이상이면 현재가격 = 발행가격
             if (pubAmount > 0) {
                 currentPrice = pubPrice;
             } else {
                 currentPrice = dao_detail.getStockPrice(stockNo);
             }
 
+            // 이전 장 가격
             int prevPrice = dao_detail.getPervPrice(stockNo);
-            int priceChange = dao_detail.getStockPriceChange(stockNo);
-            int changeRate = dao_detail.getChangeRate(stockNo);
-            
+    
+            // 현재가격 - 이전가격은 Action에서 계산 (거래가 없는 주식은 action에서 계산하라고 함)
+            int priceChange = currentPrice - prevPrice;          
+            // 등락률도 Action에서 계산
+            int changeRate = 0;
+
+            if (prevPrice != 0) {
+                changeRate = (int) Math.round(((double) priceChange / prevPrice) * 100);
+            }
 
             Map<String, Object> stock = new HashMap<String, Object>();
-            
+
             stock.put("stockNo", stockNo);
             stock.put("stockName", stockName);
             stock.put("currentPrice", currentPrice);
@@ -82,13 +89,11 @@ public class StockListUI implements Action {
             stock.put("changeRate", changeRate);
 
             stockList.add(stock);
+
         }
-        
+
         request.setAttribute("stockList", stockList);
-        
-		return "StockList.jsp";
-	}
 
+        return "StockList.jsp";
+    }
 }
-
-

--- a/src/com/school/stockGame/servlet/StockPriceAjax.java
+++ b/src/com/school/stockGame/servlet/StockPriceAjax.java
@@ -16,53 +16,103 @@ import com.school.stockGame.vo.StockVO;
 
 public class StockPriceAjax implements Action {
 
-	@Override
-	public String execute(HttpServletRequest request) throws ServletException, IOException {
-		StockListDAO daoList = new StockListDAO();
-		StockDetailDAO daoDetail = new StockDetailDAO();
+    @Override
+    public String execute(HttpServletRequest request) throws ServletException, IOException {
 
-		// 1. 등록된 주식명 목록 조회
-		List<StockVO> stockNameList = daoList.getStockNameList();
+        StockListDAO daoList = new StockListDAO();
+        StockDetailDAO daoDetail = new StockDetailDAO();
 
-		// 2. JSON으로 보낼 데이터 생성
-		List<Map<String, Object>> stockList = new ArrayList<Map<String, Object>>();
+        // 1. 등록된 주식 목록 조회
+        List<StockVO> stockNameList = daoList.getStockNameList();
 
-		for (int i = 0; i < stockNameList.size(); i++) {
-			
+        // 2. JSON으로 보낼 데이터 생성
+        List<Map<String, Object>> stockList = new ArrayList<Map<String, Object>>();
 
-			// 현재 요구사항상 stock_no는 1번부터 순서대로 존재
-			// int stockNo = i + 1;
-			
-			int stockNo = stockNameList.get(i).getStockNo();
+        for (int i = 0; i < stockNameList.size(); i++) {
+
+            int stockNo = stockNameList.get(i).getStockNo();
             String stockName = stockNameList.get(i).getName();
 
-			int currentPrice = daoDetail.getStockPrice(stockNo);
-			int prevPrice = daoDetail.getPervPrice(stockNo);
-			int priceChange = daoDetail.getStockPriceChange(stockNo);
-			int changeRate = daoDetail.getChangeRate(stockNo);
+            /*
+             * 현재가격 기준
+             *
+             * 1. 발행잔량이 1개 이상이면 현재가격 = 발행가격
+             * 2. 발행잔량이 0개이면 현재가격 = 최신 거래가격
+             *
+             * 이전가격 기준
+             *
+             * 이전가격 = 이전 장 가격(STOCKS.PREV_PRICE)
+             *
+             * 계산 기준
+             *
+             * 현재가격 - 이전가격 = currentPrice - prevPrice
+             * 등락률 = (현재가격 - 이전가격) / 이전가격 * 100
+             */
 
-			Map<String, Object> stock = new LinkedHashMap<String, Object>();
+            // 3. 발행 정보 조회
+            Map<String, Object> pubInfo = daoDetail.getStockPubInfo(stockNo);
 
-			// JS에서 stock.stockName으로 쓰고 있으므로 key 이름 반드시 stockName
-			stock.put("stockNo", stockNo);
-			stock.put("stockName", stockName);
-			stock.put("currentPrice", currentPrice);
-			stock.put("prevPrice", prevPrice);
-			stock.put("priceChange", priceChange);
-			stock.put("changeRate", changeRate);
+            int pubAmount = 0;
+            int pubPrice = 0;
 
-			stockList.add(stock);
-		}
+            if (pubInfo != null && !pubInfo.isEmpty()) {
 
-		// 3. Java 객체를 JSON 문자열로 변환
-		Gson gson = new Gson();
-		String json = gson.toJson(stockList);
+                if (pubInfo.get("pubAmount") != null) {
+                    pubAmount = ((Number) pubInfo.get("pubAmount")).intValue();
+                }
 
-		//System.out.println("StockPriceAjax Json="+json);
-		// 4. JSP에서 출력할 수 있도록 request에 저장
-		request.setAttribute("jsonData", json);
+                if (pubInfo.get("pubPrice") != null) {
+                    pubPrice = ((Number) pubInfo.get("pubPrice")).intValue();
+                }
+            }
 
-		
-		return null;
-	}
+            // 4. 현재가격 결정
+            int currentPrice = 0;
+
+            if (pubAmount > 0) {
+                // 발행잔량이 남아 있으면 현재가격은 발행가격
+                currentPrice = pubPrice;
+            } else {
+                // 발행잔량이 없으면 최신 거래가격
+                currentPrice = daoDetail.getStockPrice(stockNo);
+            }
+
+            // 5. 이전 장 가격 조회
+            int prevPrice = daoDetail.getPervPrice(stockNo);
+
+            // 6. 현재가격 - 이전 장 가격 계산
+            int priceChange = currentPrice - prevPrice;
+
+            // 7. 등락률 계산
+            int changeRate = 0;
+
+            if (prevPrice != 0) {
+                changeRate = (int) Math.round(((double) priceChange / prevPrice) * 100);
+            }
+
+            // 8. JSON으로 보낼 데이터 구성
+            Map<String, Object> stock = new LinkedHashMap<String, Object>();
+
+            stock.put("stockNo", stockNo);
+            stock.put("stockName", stockName);
+            stock.put("currentPrice", currentPrice);
+            stock.put("prevPrice", prevPrice);
+            stock.put("priceChange", priceChange);
+            stock.put("changeRate", changeRate);
+
+            stockList.add(stock);
+        }
+
+        // 9. Java 객체를 JSON 문자열로 변환
+        Gson gson = new Gson();
+        String json = gson.toJson(stockList);
+
+        // 디버깅용
+        System.out.println("StockPriceAjax Json=" + json);
+
+        // 10. FrontControllerServlet에서 jsonData를 출력하는 구조라면 그대로 사용
+        request.setAttribute("jsonData", json);
+
+        return null;
+    }
 }


### PR DESCRIPTION
현재 가격 표시해주는 기준에 맞춰서, 조건 추가함. (PR 업로드 기준, 현재 가격 표시되는 기준)
1. 발행 잔량이 1개 이상일 경우, 현재 가격은 발행 가격으로 표시해준다.
2. 발행 잔량이 0개일 경우, 학생들 간의 거래가 진행되며, 현재 가격은 학생들 간의 거래된 가격으로 표시된다.
ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ
쿼리문을 수정하지 않고, Action에서 계산하는 걸 추가하면 아래와 같은 중복 코드가 발생함.
StockPriceAjax와 StockListUI에서 거래가 0개인, 주식은 현재 StockDetailQuery에 있는 조건에 부합하지 않아 실행되지 않음.
그래서 따로 Action에서 계산값을 처리하라고 하심.

그러면, 현재가격, 현재가격 - 이전 (장) 가격, 등락률을 계산하는 로직을 또 적어야 함.
이미 거래가 1개 이상인 주식은 쿼리문에서 select만 하면 됨. 근데 거래가 0개인 주식을 위해, Action에서 같은 로직을 또 적는 거임.

그런데, StockListUI는 처음 보여지는 화면이고, StockPriceAjax는 비동기를 위한 화면이라서, 2개의 파일에 같은 계산을 하는 로직이 들어감. 또 중복코드임.

- 결론
1.  기존 기준대로 진행한다면, (UI에 뿌려질 데이터들은, 쿼리문에서 조건을 걸어서 java에선 get만 하면 됨.) 쿼리문에 조건을 넣는 게 지금보단 중복을 줄임. 
2. Action에서 조건 거는 게 더 쉽다라고 생각들면, 이대로 진행. (지금 이렇게 진행하라고 해서, 한 거임.)
3. 다른 의견 있으면, 제발 물어보면 말하지 말고. 카톡이든 코멘트든 바로 전달할 것. 